### PR TITLE
Update to allow missing callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ function map(leg, value, brightness, piglow) {
 module.exports = {
     start: function(options, callback) {
         options = options || {};
+        callback = callback || function(){};
 
         piglowInterface(function(error, piGlowHandler) {
             if(error) {


### PR DESCRIPTION
This enables the example in the README to work so the following line
of code can be invoked without specifying a callback function:
  `piglowClock.start(options);`
